### PR TITLE
Fix a bug where a namespace is not correctly encoded.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -238,6 +238,8 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		$path = $conf['savedir'].'/pages/'.str_replace(':', '/', $ns);
 		if ($conf['fnencode'] == 'safe')
 			$path = SafeFn::encode($path);
+		else if ($conf['fnencode'] == 'url')
+			$path = utf8_encodeFN($path);
 		if (!is_dir($path)) {
 			msg(sprintf($this->getLang('dontexist'), $ns), -1);
 			return false;


### PR DESCRIPTION
If a namespace is specified with non-ascii characters and "fnencode" is set to "url", the namespace is not encoded correctly. I added code for url-encoding for fixing this bug.

I use your plugin in Japanese environment and this bug causes annoying issues, so I'm very glad if you merge this pull request.