### PR TITLE
Add a show_leading_ns option

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -7,3 +7,4 @@ $conf['nocache'] = false;
 $conf['hide_acl_nsnotr'] = false;
 $conf['show_acl'] = false;
 $conf['useheading'] = true;
+$conf['show_leading_ns'] = false;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,3 +7,4 @@ $meta['nocache'] = array('onoff');
 $meta['hide_acl_nsnotr'] = array('onoff');
 $meta['show_acl'] = array('onoff');
 $meta['useheading'] = array('onoff');
+$meta['show_leading_ns'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,3 +7,4 @@ $lang['nocache'] = "Disable page cache where catlist is used";
 $lang['hide_acl_nsnotr'] = "Hide namespaces for which the user doesn't have ACL Read permission";
 $lang['show_acl'] = "Ignore ACLs (show everything, regardless of the user) and show user permissions for each item";
 $lang['useheading'] = "Use first heading for pagenames (regardless of dokuwiki's 'useheading' setting)";
+$lang['show_leading_ns'] = "Show leading namespaces to a page for which a user has ACL Read regardless of user ACLs on namespace.";

--- a/syntax.php
+++ b/syntax.php
@@ -367,7 +367,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		}
 		if ($data['displayType'] == CATLIST_DISPLAY_LIST) $renderer->doc .= '<ul '.$global_ul_attr.'>';
 		$this->_recurse($renderer, $data, $data['tree']);
-		$perm_create = auth_quickaclcheck($ns.':*') >= AUTH_CREATE;
+		$perm_create = $this->_cached_quickaclcheck($ns.':*') >= AUTH_CREATE;
 		$ns_button = ($ns == '') ? '' : $ns.':';
 		if ($data['createPageButtonNs'] && $perm_create) $this->_displayAddPageButton($renderer, $ns_button, $data['displayType']);
 		if ($data['displayType'] == CATLIST_DISPLAY_LIST) $renderer->doc .= '</ul>';
@@ -419,7 +419,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 				$this->_displayNSEnd($renderer, $data['displayType'], $item['buttonid']);
 			} else { 
 				// It's a page
-				$perms = auth_quickaclcheck($item['id']);
+				$perms = $this->_cached_quickaclcheck($item['id']);
 				if ($perms < AUTH_READ && (!$data['show_perms'] || $limitedNSPerms)) continue;
 				if ($data['hide_index'] && in_array($item['id'], $data['index_pages'])) continue;
 				$this->_displayPage($renderer, $item, $data['displayType'], ($data['show_perms'] ? $perms : NULL));

--- a/syntax.php
+++ b/syntax.php
@@ -84,7 +84,8 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		              'hide_index' => (boolean)$this->getConf('hide_index'),
 		              'index_priority' => array(),
 		              'nocache' => (boolean)$this->getConf('nocache'),
-		              'hide_nsnotr' => (boolean)$this->getConf('hide_acl_nsnotr'), 'show_perms' => (boolean)$this->getConf('show_acl') );
+		              'hide_nsnotr' => (boolean)$this->getConf('hide_acl_nsnotr'), 'show_perms' => (boolean)$this->getConf('show_acl'),
+		              'show_leading_ns' => (boolean)$this->getConf('show_leading_ns') );
 
 		$index_priority = explode(',', $this->getConf('index_priority'));
 		foreach ($index_priority as $index_type) {
@@ -374,22 +375,52 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		return true;
 	}
 	
-	function _recurse (&$renderer, $data, $_TREE) {
+	function _cached_quickaclcheck($id) {
+		static $cache = array();
+
+		if (!isset($cache[$id]))
+			$cache[$id] = auth_quickaclcheck($id);
+
+		return $cache[$id];
+	}
+
+	function _any_child_perms ($data, $_TREE) {
+		foreach ($_TREE as $item) {
+			if (isset($item['_'])) {
+				$perms = $this->_cached_quickaclcheck($item['id'].':*');
+				if ($perms >= AUTH_READ || $this->_any_child_perms($data, $item['_']))
+					return true;
+			} else {
+				$perms = $this->_cached_quickaclcheck($item['id']);
+				if ($perms >= AUTH_READ)
+					return true;
+			}
+		}
+		return false;
+	}
+
+	function _recurse (&$renderer, $data, $_TREE, $limitedNSPerms = false) {
 		foreach ($_TREE as $item) {
 			if (isset($item['_'])) {
 				// It's a namespace
-				$perms = auth_quickaclcheck($item['id'].':*');
-				if ($perms < AUTH_READ && $data['hide_nsnotr'] && !$data['show_perms']) continue;
+				$perms = $this->_cached_quickaclcheck($item['id'].':*');
+				if ($perms < AUTH_READ && $data['hide_nsnotr'] && !$data['show_perms']) {
+					if (!$data['show_leading_ns'])
+						continue;
+					// Walk the tree below this, see if any page/namespace below this has access
+					if (!$this->_any_child_perms($data, $item['_']))
+						continue;
+				}
 				$item['linkdisp'] = $item['linkdisp'] && ($perms >= AUTH_READ);
 				$item['buttonid'] = ($perms >= AUTH_CREATE) ? $item['buttonid'] : NULL;
 				$this->_displayNSBegin($renderer, $data, $item['title'], $item['linkdisp'], $item['linkid'], ($data['show_perms'] ? $perms : NULL));
-				if ($perms >= AUTH_READ)
-					$this->_recurse($renderer, $data, $item['_']);
+				if ($perms >= AUTH_READ || ($data['show_leading_ns'] && ($limitedNSPerms = $this->_any_child_perms($data, $item['_']))))
+					$this->_recurse($renderer, $data, $item['_'], $limitedNSPerms);
 				$this->_displayNSEnd($renderer, $data['displayType'], $item['buttonid']);
 			} else { 
 				// It's a page
 				$perms = auth_quickaclcheck($item['id']);
-				if ($perms < AUTH_READ && !$data['show_perms']) continue;
+				if ($perms < AUTH_READ && (!$data['show_perms'] || $limitedNSPerms)) continue;
 				if ($data['hide_index'] && in_array($item['id'], $data['index_pages'])) continue;
 				$this->_displayPage($renderer, $item, $data['displayType'], ($data['show_perms'] ? $perms : NULL));
 			}

--- a/syntax.php
+++ b/syntax.php
@@ -404,7 +404,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 			if (isset($item['_'])) {
 				// It's a namespace
 				$perms = $this->_cached_quickaclcheck($item['id'].':*');
-				if ($perms < AUTH_READ && $data['hide_nsnotr'] && !$data['show_perms']) {
+				if ($perms < AUTH_READ && (($data['hide_nsnotr'] && !$data['show_perms']) || $limitedNSPerms)) {
 					if (!$data['show_leading_ns'])
 						continue;
 					// Walk the tree below this, see if any page/namespace below this has access


### PR DESCRIPTION
This is used in scenarios where a user may not have full access to a namespace,
but they might have access to pages within a namespace. For instance, consider
the following layout:

FAQ
- Restricted
- - Entry1
- - Entry2
- - Entry3
- Public
- - Entry1
- - Entry2
- - Entry3

Along with the following ACLs:

FAQ:Public:* -> @ALL/Read
FAQ:Restricted:* -> @RestrictedPeople/read, @ALL/None
FAQ:Restricted:Entry3 -> @FurtherRestrictedPeople/read

Such a setup allows RestrictedPeople complete access to the Restricted namespace,
while giving FurtherRestrictedPeople limited insight into the namespace -- as far
as they can read into it.

This option was designed for interactions w/ hide_acl_nsnotr and show_acl properly.
With show_acl, still only FAQ:Restricted:Entry3 would be shown if a user didn't have
ACLs for FAQ:Restricted.