### PR TITLE
New config item 'showhead' controls default headline display behaviour

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -7,4 +7,5 @@ $conf['nocache'] = false;
 $conf['hide_acl_nsnotr'] = false;
 $conf['show_acl'] = false;
 $conf['useheading'] = true;
+$conf['showhead'] = true;
 $conf['show_leading_ns'] = false;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,4 +7,5 @@ $meta['nocache'] = array('onoff');
 $meta['hide_acl_nsnotr'] = array('onoff');
 $meta['show_acl'] = array('onoff');
 $meta['useheading'] = array('onoff');
+$meta['showhead'] = array('onoff');
 $meta['show_leading_ns'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,4 +7,5 @@ $lang['nocache'] = "Disable page cache where catlist is used";
 $lang['hide_acl_nsnotr'] = "Hide namespaces for which the user doesn't have ACL Read permission";
 $lang['show_acl'] = "Ignore ACLs (show everything, regardless of the user) and show user permissions for each item";
 $lang['useheading'] = "Use first heading for pagenames (regardless of dokuwiki's 'useheading' setting)";
+$lang['showhead'] = "Show headline by default; individual override with -noHead and -showHead.";
 $lang['show_leading_ns'] = "Show leading namespaces to a page for which a user has ACL Read regardless of user ACLs on namespace.";

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -7,4 +7,5 @@ $lang['nocache'] = "Désactive le cache de la page quand catlist est utilisé.";
 $lang['hide_acl_nsnotr'] = "N'affiche pas les namespaces pour lesquels l'utilisateur n'a pas droit de lecture.";
 $lang['show_acl'] = "Débogage : ignore les ACLs (affiche tout, quelque soit l'utilisateur) et affiche les permissions de l'utilisateur.";
 $lang['useheading'] = "Utilise le premier titre comme nom de page (indépendamment du 'useheading' global)";
+$lang['showhead'] = "Afficher le titre par défaut; remplacement individuel avec -noHead ou -showHead.";
 $lang['show_leading_ns'] = "Affiche le namespace si il existe un élément fils pour lequel l'utilisateur a la permission de lecture.";

--- a/syntax.php
+++ b/syntax.php
@@ -76,7 +76,8 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		              'exclupage' => array(), 'excluns' => array(), 'exclunsall' => array(), 'exclunspages' => array(), 'exclunsns' => array(),
 		              'exclutype' => 'id', 
 		              'createPageButtonNs' => true, 'createPageButtonSubs' => false, 
-		              'head' => true, 'headTitle' => NULL, 'smallHead' => false, 'linkStartHead' => true, 'hn' => 'h1',
+		              'head' => (boolean)$this->getConf('showhead'),
+                              'headTitle' => NULL, 'smallHead' => false, 'linkStartHead' => true, 'hn' => 'h1',
 		              'useheading' => (boolean)$this->getConf('useheading'),
 		              'nsuseheading' => NULL, 'nsLinks' => CATLIST_NSLINK_AUTO,
 		              'columns' => 0, 'maxdepth' => 0,
@@ -145,6 +146,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 
 		// Head options
 		$this->_checkOption($match, "noHead", $data['head'], false);
+		$this->_checkOption($match, "showHead", $data['head'], true);
 		$this->_checkOption($match, "smallHead", $data['smallHead'], true);
 		$this->_checkOption($match, "noLinkStartHead", $data['linkStartHead'], false);
 		if (preg_match("/-(h[1-5])/i", $match, $found)) {


### PR DESCRIPTION
This PR adds a new config item `showHead`, and a new option `-showHead`.

The config item may be set to:

- `true` (default): no change to behaviour.
- `false`: headline will never be shown unless new option `-showHead` is specified.

A `settings.php` description of the config item is provided in English and French.

### Purpose
Setting `showHead` to `false` provides the opposite of the default headline display behaviour. This can be useful to avoid the need to specify the `-noHead` option frequently, e.g. on a wiki which makes extensive use of `catlist`, and where a design decision has been taken that the headline should not typically be displayed.

### Example
When `showHead` config item is set to `false`:
```<catlist .>```
will not display the headline, but:
```<catlist . -showHead>```
will show the headline.