### PR TITLE
sortByTitle replace strcmp with strnatcasecmp

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -341,7 +341,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 						return isset($b['_']);
 					$a_title = ($data['sort_by_title'] ? $a['title'] : $a['name']);
 					$b_title = ($data['sort_by_title'] ? $b['title'] : $b['name']);
-					$b = strcmp($a_title, $b_title);
+					$b = strnatcasecmp($a_title, $b_title);
 					if ($data['sort_order'] == CATLIST_SORT_DESCENDING)
 						$b = !$b;
 					return $b;


### PR DESCRIPTION
replaced sort function 
to get a natural sorting including digits in the title
the old way with strcmp doesn´t sort in a natural way.

Example:
1st page title:  **1. some text**
2nd page title: **2. some text**
3rd page title: **11. some text**
4th page title: **4. some text**

result after sorting with `strcmp` 
- **1. some text**
- **11. some text**
- **2. some text**
- **4. some text**

result after sorting with `strnatcasecmp` 
- **1. some text**
- **2. some text**
- **4. some text**
- **11. some text**