### PR TITLE
use datadir from configuration instead of manually building the path to pages

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -247,7 +247,7 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		global $conf;
 			// Prepare
 		$ns = $data['ns'];
-		$path = $conf['savedir'].'/pages/'.str_replace(':', '/', $ns);
+		$path = $conf['datadir'].'/'.str_replace(':', '/', $ns);
 		$path = utf8_encodeFN($path);
 		if (!is_dir($path)) {
 			if ($data['show_notfound_error'])


### PR DESCRIPTION
Hello,

while using xmlrpc access to view pages using the catlist plugin, the page is not rendered as expected. (cf issue logged here: https://github.com/fabienli/DokuwikiAndroid/issues/5 ).
Root cause of the issue comes from the way to find the list of pages, in case the folder where data is stored is a relative folder (default configuration).

- access from doku.php (website usual access): working fine
- access from lib/exe/xmlrpc.php (remote access): the pages are searched within lib/exe/data/...

This Pull Request aims at changing the way the path is computed.