### PR TITLE
add %%CURRENT_PAGE%% magic placeholder

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -284,6 +284,8 @@ class syntax_plugin_catlist extends DokuWiki_Syntax_Plugin {
 		$ns = $data['ns'];
 		if($ns == '%%CURRENT_NAMESPACE%%')
 			$ns = getNS(cleanID(getID())); // update namespace to the one currently displayed
+		if($ns == '%%CURRENT_PAGE%%')
+			$ns = cleanID(getID()); // this is used when pages are single pages instead of namespaces
 		$path = str_replace(':', '/', $ns);
 		$path = $conf['datadir'].'/'.utf8_encodeFN($path);
 		if (!is_dir($path)) {


### PR DESCRIPTION
Useful for default page templates (like `<catlist %%CURRENT_PAGE%% -noHead -sortAscending -hideNotFoundMsg>`)

When a page is created by default nothing will be shown with that catlist. When creating subpages (without moving the original page into the new namespace and renaming it to start) they will be shown on the original page as links automatically.

I'm not sure what the difference between `getID()` and `global $ID` is, but I thought it would be better style adding the variable here instead of in the `handle` function.