### PR TITLE
replace start config setting by text <start>

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,7 +2,7 @@
 
 $lang['default_sort'] = "Default sort order";
 $lang['hide_index'] = "Hide pages that are used as index pages (main page of a namespace)";
-$lang['index_priority'] = "Priority order of pages used as index pages, between start, inside and outside. Exemple with the namespace foo:bar: start= foo:bar:".$conf['start']." ; outside= foo:bar ; inside= foo:bar:bar";
+$lang['index_priority'] = "Priority order of pages used as index pages, between start, inside and outside. Exemple with the namespace foo:bar: start= foo:bar:&lt;start&gt;; outside= foo:bar ; inside= foo:bar:bar";
 $lang['nocache'] = "Disable page cache where catlist is used";
 $lang['hide_acl_nsnotr'] = "Hide namespaces for which the user doesn't have ACL Read permission";
 $lang['show_acl'] = "Ignore ACLs (show everything, regardless of the user) and show user permissions for each item";


### PR DESCRIPTION
Nice way of showing the options. Unfortunately, the Translation Tool does not support php parsing in these strings. Therefore, to use the Tool, the strings has to be simplified.